### PR TITLE
Refine Redux store initialization for Next.js app

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,13 +1,22 @@
 'use client';
 
+import type { ReactNode } from 'react';
+import { useRef } from 'react';
 import { Provider } from 'react-redux';
 
-import { store } from '@/store';
+import { makeStore, type AppPreloadedState, type AppStore } from '@/store';
 
 export interface ProvidersProps {
-  children: React.ReactNode;
+  children: ReactNode;
+  preloadedState?: AppPreloadedState;
 }
 
-export default function Providers({ children }: ProvidersProps) {
-  return <Provider store={store}>{children}</Provider>;
+export default function Providers({ children, preloadedState }: ProvidersProps) {
+  const storeRef = useRef<AppStore>();
+
+  if (!storeRef.current) {
+    storeRef.current = makeStore(preloadedState);
+  }
+
+  return <Provider store={storeRef.current}>{children}</Provider>;
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,25 +1,31 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
-import courseReducer from './courses.slice';
-import userReducer from './user.slice';
-import coursesReducer from './courses.slice';
-import wishlistReducer from './wishlist.slice';
-import childrenReducer from './children.slice';
 import assessmentReducer from './assessment.slice';
+import childrenReducer from './children.slice';
+import coursesReducer from './courses.slice';
+import userReducer from './user.slice';
+import wishlistReducer from './wishlist.slice';
 
-export const store = configureStore({
-  reducer: {
-    courses: courseReducer,
-    user: userReducer,
-    wishlist: wishlistReducer,
-    children: childrenReducer,
-    assessment: assessmentReducer,
-  },
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: false,
-    }),
+const rootReducer = combineReducers({
+  assessment: assessmentReducer,
+  children: childrenReducer,
+  courses: coursesReducer,
+  user: userReducer,
+  wishlist: wishlistReducer,
 });
 
-export type RootState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof rootReducer>;
+
+export type AppPreloadedState = Partial<RootState>;
+
+export const makeStore = (preloadedState?: AppPreloadedState) =>
+  configureStore({
+    reducer: rootReducer,
+    preloadedState,
+    devTools: process.env.NODE_ENV !== 'production',
+  });
+
+export type AppStore = ReturnType<typeof makeStore>;
+export type AppDispatch = AppStore['dispatch'];
+
+export const store = makeStore();


### PR DESCRIPTION
## Summary
- restructure the Redux store around a shared root reducer and factory to keep DevTools support without disabling serializable checks
- add typed helpers for the store, dispatch, and optional preloaded state to support scalable initialization
- update the Next.js provider to lazily create the store with optional preloaded state for safer per-request isolation

## Testing
- npm run lint *(fails: existing Next.js lint configuration uses removed CLI options)*
- npm run type-check *(fails: pre-existing typing issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68fa74d35090832a9fddab0f8f326a9d