### PR TITLE
Fix production build failure from Google font fetch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import Providers from './providers';
 import { env } from '@/config/env';
 import {
@@ -11,8 +10,6 @@ import {
 } from '@/lib/redux-ssr';
 import { selectMetadataSnapshot } from '@/store/selectors/metadata.selectors';
 import '@/styles/globals.css';
-
-const inter = Inter({ subsets: ['latin'], variable: '--font-geist-sans' });
 
 const SITE_NAME = 'Ashravi';
 const DEFAULT_TITLE = 'Ashravi - Empowering Parents to Build Positive Child Behaviors';
@@ -108,7 +105,7 @@ export default async function RootLayout({
           }}
         />
       </head>
-      <body className={inter.variable}>
+      <body>
         <Providers preloadedState={preloadedState}>{resolvedChildren}</Providers>
       </body>
     </html>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
 @import './tokens.css';
 @tailwind base;
 @tailwind components;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,4 +1,6 @@
 :root {
+  --font-geist-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   /* Light theme colors */
   --color-bg: #ffffff;
   --color-text: #111111;


### PR DESCRIPTION
## Summary
- stop bundling the Inter Google Font during build and load it via CSS at runtime instead
- define the shared font CSS variable directly in the token stylesheet so the body styling keeps working without `next/font`

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fd9c31ac832ab48a12e1df32b14c)