### PR TITLE
Add course payment flow and redirect unpaid learners to `/course/[id]/payment`

### DIFF
--- a/src/app/course/[id]/payment/page.tsx
+++ b/src/app/course/[id]/payment/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import type { AnyAction } from '@reduxjs/toolkit';
+
+import CoursePaymentPage from '@/components/pages/CoursePaymentPage/CoursePaymentPage';
+import {
+  awaitServerQueries,
+  getMiddlewarePreloadedState,
+  initializeServerStore,
+  stageServerPreloadedState,
+} from '@/lib/redux-ssr';
+import { coursesApi } from '@/store/api/courses.api';
+
+interface CoursePaymentParams {
+  id: string;
+}
+
+const SITE_NAME = 'Asharvi Web';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<CoursePaymentParams>;
+}): Promise<Metadata> {
+  const { id } = await params;
+
+  return {
+    title: `Course Payment | ${SITE_NAME}`,
+    description: 'Complete your course purchase with a secure payment flow.',
+    openGraph: {
+      title: `Course Payment | ${SITE_NAME}`,
+      description: 'Review course details and continue to payment.',
+      type: 'article',
+      url: `/course/${id}/payment`,
+    },
+  };
+}
+
+export default async function CoursePaymentRoute({
+  params,
+}: {
+  params: Promise<CoursePaymentParams>;
+}) {
+  const { id } = await params;
+  const middlewareState = await getMiddlewarePreloadedState();
+  const store = initializeServerStore(middlewareState);
+
+  store.dispatch(
+    coursesApi.endpoints.detail.initiate(id) as unknown as AnyAction
+  );
+
+  await awaitServerQueries(store);
+  await stageServerPreloadedState(store);
+
+  return <CoursePaymentPage courseId={id} />;
+}

--- a/src/components/organisms/CourseHero/CourseHero.tsx
+++ b/src/components/organisms/CourseHero/CourseHero.tsx
@@ -23,6 +23,7 @@ interface CourseHeroProps {
   priceLabel: string;
   originalPriceLabel?: string | null;
   onStartLearning: () => void;
+  primaryActionLabel?: string;
   onWishlistToggle?: () => void;
   wishlistLabel?: string;
   wishlistDisabled?: boolean;
@@ -44,6 +45,7 @@ export default function CourseHero({
   priceLabel,
   originalPriceLabel,
   onStartLearning,
+  primaryActionLabel,
   onWishlistToggle,
   wishlistLabel,
   wishlistDisabled,
@@ -56,6 +58,7 @@ export default function CourseHero({
   const resolvedWishlistLabel =
     wishlistLabel ?? (isWishlisted ? 'Remove from wishlist' : 'Add to wishlist');
   const wishlistButtonDisabled = wishlistDisabled ?? !onWishlistToggle;
+  const actionLabel = primaryActionLabel ?? 'Start learning';
 
   return (
     <section className="course-detail-hero">
@@ -92,7 +95,7 @@ export default function CourseHero({
 
         <div className="course-detail-actions">
           <Button variant="primary" size="lg" onClick={onStartLearning}>
-            Start learning
+            {actionLabel}
           </Button>
           <Button
             variant="secondary"

--- a/src/components/pages/CourseDetailPage/CourseDetailPage.tsx
+++ b/src/components/pages/CourseDetailPage/CourseDetailPage.tsx
@@ -254,6 +254,18 @@ export default function CourseDetailPage({ courseId }: CourseDetailPageProps) {
     originalPrice && originalPrice > priceAmount
       ? formatCurrency(originalPrice, course.price?.currency)
       : null;
+  const isPaidCourse = priceAmount > 0;
+  const isPurchased = course.isPurchased ?? false;
+  const primaryActionLabel = isPaidCourse && !isPurchased ? 'Purchase course' : 'Start learning';
+
+  const handleStartLearning = () => {
+    if (isPaidCourse && !isPurchased) {
+      router.push(`/course/${courseId}/payment`);
+      return;
+    }
+
+    router.push(`/learn/${courseId}`);
+  };
 
   const sections: Section[] = Array.isArray(course.sections)
     ? (course.sections as Section[])
@@ -303,7 +315,8 @@ export default function CourseDetailPage({ courseId }: CourseDetailPageProps) {
             thumbnail={thumbnail}
             priceLabel={priceLabel}
             originalPriceLabel={originalPriceLabel}
-            onStartLearning={() => router.push(`/learn/${courseId}`)}
+            onStartLearning={handleStartLearning}
+            primaryActionLabel={primaryActionLabel}
             onWishlistToggle={handleWishlistToggle}
             wishlistLabel={wishlistLabel}
             wishlistDisabled={wishlistDisabled}

--- a/src/components/pages/CoursePaymentPage/CoursePaymentPage.tsx
+++ b/src/components/pages/CoursePaymentPage/CoursePaymentPage.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useMemo, useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import PublicNavbar from '@/components/organisms/PublicNavbar';
+import Footer from '@/components/organisms/Footer';
+import Button from '@/components/atoms/Button';
+import SpinnerIcon from '@/components/icons/SpinnerIcon';
+
+import { useAuthGuard } from '@/hooks/useAuthGuard';
+import { useFeatureModules } from '@/hooks/useFeatureModule';
+import { useAppSelector } from '@/hooks/useAppSelector';
+import type { FeatureModuleKey } from '@/store/modules/registry';
+import { coursesApi, useCourseDetailQuery } from '@/store/api/courses.api';
+import { selectMockCourses } from '@/store/selectors/mock.selectors';
+import type { Course } from '@/types';
+
+import './index.css';
+
+const formatCurrency = (amount?: number, currency = 'USD'): string => {
+  if (!amount || amount <= 0) {
+    return 'Free';
+  }
+
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `$${amount.toFixed(2)}`;
+  }
+};
+
+const formatDuration = (seconds?: number): string => {
+  if (!seconds || !Number.isFinite(seconds) || seconds <= 0) {
+    return 'Self-paced';
+  }
+
+  const totalMinutes = Math.round(seconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours === 0) {
+    return `${minutes}m total`;
+  }
+
+  if (hours < 10) {
+    return `${hours}h ${minutes}m total`;
+  }
+
+  return `${hours}h total`;
+};
+
+const resolveInstructorName = (instructor?: Course['instructor']): string => {
+  if (!instructor) {
+    return 'Unknown Instructor';
+  }
+
+  if (typeof instructor === 'string') {
+    return 'Instructor';
+  }
+
+  return instructor.name ?? 'Unknown Instructor';
+};
+
+export default function CoursePaymentPage({ courseId }: { courseId: string }) {
+  const { isAuthenticated, isChecking } = useAuthGuard({ redirectTo: '/auth/login' });
+  const router = useRouter();
+
+  const featureKeys = useMemo<FeatureModuleKey[]>(
+    () => (process.env.NODE_ENV !== 'production' ? ['courses', 'wishlist', 'mock'] : ['courses', 'wishlist']),
+    []
+  );
+  const featuresReady = useFeatureModules(featureKeys);
+
+  const cachedCourse = coursesApi.endpoints.detail.useQueryState(courseId);
+  const mockCourses = useAppSelector(selectMockCourses);
+  const shouldFetch = !cachedCourse.data;
+  const { isFetching: isFetchingFallback } = useCourseDetailQuery(courseId, {
+    skip: !isAuthenticated || !shouldFetch,
+  });
+
+  const normalizedCourseId = courseId.trim().toLowerCase();
+  const fallbackCourse = useMemo(
+    () =>
+      mockCourses.find((mock: Course) => {
+        const candidates = [mock.id, mock.slug];
+        return candidates.some((candidate) => candidate?.toLowerCase() === normalizedCourseId);
+      }),
+    [mockCourses, normalizedCourseId]
+  );
+
+  const course = cachedCourse.data?.data ?? fallbackCourse;
+  const isPaidCourse = (course?.price?.amount ?? 0) > 0;
+  const isPurchased = course?.isPurchased ?? false;
+  const isLoadingState = isChecking || !featuresReady || (!course && isFetchingFallback);
+
+  useEffect(() => {
+    if (!course || isChecking || !featuresReady) {
+      return;
+    }
+
+    if (!isPaidCourse || isPurchased) {
+      router.replace(`/learn/${courseId}`);
+    }
+  }, [course, courseId, featuresReady, isChecking, isPaidCourse, isPurchased, router]);
+
+  if (isLoadingState) {
+    return (
+      <div className="course-payment-page">
+        <PublicNavbar />
+        <main className="course-payment-main">
+          <div className="course-payment-container">
+            <div className="course-payment-loading">
+              <SpinnerIcon size={48} />
+              <p>Preparing your checkout...</p>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!course) {
+    return (
+      <div className="course-payment-page">
+        <PublicNavbar />
+        <main className="course-payment-main">
+          <div className="course-payment-container">
+            <div className="course-payment-error">
+              <h1>Course not found</h1>
+              <p>We couldn&apos;t load this course right now. Please return to the course page.</p>
+              <Link href="/courses" className="course-payment-error-link">
+                Browse courses
+              </Link>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  const priceLabel = formatCurrency(course.price?.amount ?? course.originalPrice ?? 0, course.price?.currency);
+  const durationLabel = formatDuration(course.metadata?.totalDuration);
+  const instructorName = resolveInstructorName(course.instructor);
+
+  return (
+    <div className="course-payment-page">
+      <PublicNavbar />
+      <main className="course-payment-main">
+        <div className="course-payment-container">
+          <nav className="course-payment-breadcrumbs" aria-label="Breadcrumb">
+            <Link href="/">Home</Link>
+            <span className="course-payment-breadcrumb-divider">/</span>
+            <Link href="/courses">Courses</Link>
+            <span className="course-payment-breadcrumb-divider">/</span>
+            <Link href={`/course/${courseId}`}>Course details</Link>
+            <span className="course-payment-breadcrumb-divider">/</span>
+            <span aria-current="page">Payment</span>
+          </nav>
+
+          <header className="course-payment-header">
+            <h1>Complete your purchase</h1>
+            <p>Review your course details and proceed to payment when you&apos;re ready.</p>
+          </header>
+
+          <div className="course-payment-grid">
+            <section className="course-payment-summary">
+              <div className="course-payment-summary-card">
+                <div className="course-payment-summary-media">
+                  <img
+                    src={course.coverImage ?? course.thumbnail ?? '/images/course-placeholder.jpg'}
+                    alt={course.title ?? 'Course preview'}
+                  />
+                </div>
+                <div className="course-payment-summary-content">
+                  <h2>{course.title ?? 'Course purchase'}</h2>
+                  <p className="course-payment-summary-description">
+                    {course.shortDescription ?? course.description ?? 'Course details'}
+                  </p>
+                  <dl className="course-payment-summary-details">
+                    <div>
+                      <dt>Instructor</dt>
+                      <dd>{instructorName}</dd>
+                    </div>
+                    <div>
+                      <dt>Duration</dt>
+                      <dd>{durationLabel}</dd>
+                    </div>
+                    <div>
+                      <dt>Level</dt>
+                      <dd>{course.level ?? 'All levels'}</dd>
+                    </div>
+                    <div>
+                      <dt>Price</dt>
+                      <dd>{priceLabel}</dd>
+                    </div>
+                  </dl>
+                  <div className="course-payment-summary-actions">
+                    <Button variant="secondary" size="md" onClick={() => router.push(`/course/${courseId}`)}>
+                      Back to course
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="course-payment-gateway" aria-label="Payment gateway placeholder">
+              <div className="course-payment-gateway-card">
+                <h2>Payment gateway</h2>
+                <p>
+                  A secure payment provider will be integrated here. You&apos;ll be able to pay with your
+                  preferred method once the gateway is connected.
+                </p>
+                <div className="course-payment-gateway-placeholder">
+                  <span>Payment provider widget placeholder</span>
+                </div>
+                <Button variant="primary" size="lg" disabled>
+                  Proceed to payment
+                </Button>
+                <p className="course-payment-gateway-note">
+                  Payments are not yet enabled in this environment.
+                </p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/pages/CoursePaymentPage/index.css
+++ b/src/components/pages/CoursePaymentPage/index.css
@@ -1,0 +1,174 @@
+.course-payment-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-background, #f9fafb);
+  color: var(--color-text, #0f172a);
+}
+
+.course-payment-main {
+  flex: 1;
+  padding: 48px 0 72px;
+}
+
+.course-payment-container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.course-payment-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: var(--color-muted, #64748b);
+}
+
+.course-payment-breadcrumbs a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.course-payment-breadcrumbs a:hover {
+  color: var(--color-primary, #2563eb);
+}
+
+.course-payment-breadcrumb-divider {
+  color: var(--color-muted, #94a3b8);
+}
+
+.course-payment-header h1 {
+  font-size: clamp(2rem, 2.6vw, 2.6rem);
+  margin-bottom: 8px;
+}
+
+.course-payment-header p {
+  color: var(--color-muted, #64748b);
+  margin: 0;
+}
+
+.course-payment-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.course-payment-summary-card,
+.course-payment-gateway-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.course-payment-summary-card {
+  gap: 24px;
+}
+
+.course-payment-summary-media img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  border-radius: 16px;
+}
+
+.course-payment-summary-content h2 {
+  font-size: 1.6rem;
+  margin: 0 0 8px;
+}
+
+.course-payment-summary-description {
+  color: var(--color-muted, #64748b);
+  margin: 0 0 16px;
+}
+
+.course-payment-summary-details {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.course-payment-summary-details div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 0.95rem;
+}
+
+.course-payment-summary-details dt {
+  color: var(--color-muted, #64748b);
+  font-weight: 500;
+}
+
+.course-payment-summary-details dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text, #0f172a);
+}
+
+.course-payment-summary-actions {
+  margin-top: 8px;
+}
+
+.course-payment-gateway-card h2 {
+  font-size: 1.4rem;
+  margin: 0;
+}
+
+.course-payment-gateway-card p {
+  color: var(--color-muted, #64748b);
+  margin: 0;
+}
+
+.course-payment-gateway-placeholder {
+  border: 2px dashed #cbd5f5;
+  border-radius: 16px;
+  padding: 32px;
+  text-align: center;
+  color: #475569;
+  background: #f8fafc;
+}
+
+.course-payment-gateway-note {
+  font-size: 0.9rem;
+  color: var(--color-muted, #94a3b8);
+  margin-top: 4px;
+}
+
+.course-payment-loading,
+.course-payment-error {
+  background: #fff;
+  border-radius: 20px;
+  padding: 48px;
+  text-align: center;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.course-payment-error h1 {
+  margin-bottom: 12px;
+}
+
+.course-payment-error-link {
+  display: inline-block;
+  margin-top: 16px;
+  color: var(--color-primary, #2563eb);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .course-payment-main {
+    padding: 32px 0 56px;
+  }
+
+  .course-payment-summary-details div {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/components/pages/LearningPage/LearningPage.tsx
+++ b/src/components/pages/LearningPage/LearningPage.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import PublicNavbar from '@/components/organisms/PublicNavbar';
 import Footer from '@/components/organisms/Footer';
@@ -122,6 +123,7 @@ interface NoteEntry {
 
 export default function LearningPage({ courseId }: { courseId: string }) {
   const { isAuthenticated, isChecking } = useAuthGuard({ redirectTo: '/auth/login' });
+  const router = useRouter();
 
   const featureKeys = useMemo<FeatureModuleKey[]>(
     () => (process.env.NODE_ENV !== 'production' ? ['courses', 'wishlist', 'mock'] : ['courses', 'wishlist']),
@@ -144,6 +146,8 @@ export default function LearningPage({ courseId }: { courseId: string }) {
 
   const course = cachedCourse.data?.data ?? fallbackCourse;
   const userProfile = useAppSelector(selectUserProfile);
+  const isPaidCourse = (course?.price?.amount ?? 0) > 0;
+  const isPurchased = course?.isPurchased ?? false;
 
   const lectures = useMemo(() => flattenCourseLectures(course), [course]);
   const initialLecture = useMemo(
@@ -346,6 +350,16 @@ export default function LearningPage({ courseId }: { courseId: string }) {
       : undefined;
 
   const isLoadingState = isChecking || !featuresReady || (!course && isFetchingFallback);
+
+  useEffect(() => {
+    if (!course || isChecking || !featuresReady) {
+      return;
+    }
+
+    if (isPaidCourse && !isPurchased) {
+      router.replace(`/course/${courseId}/payment`);
+    }
+  }, [course, courseId, featuresReady, isChecking, isPaidCourse, isPurchased, router]);
 
   if (isLoadingState) {
     return (

--- a/src/components/pages/LearningPage/LearningPage.tsx
+++ b/src/components/pages/LearningPage/LearningPage.tsx
@@ -146,7 +146,8 @@ export default function LearningPage({ courseId }: { courseId: string }) {
 
   const course = cachedCourse.data?.data ?? fallbackCourse;
   const userProfile = useAppSelector(selectUserProfile);
-  const isPaidCourse = (course?.price?.amount ?? 0) > 0;
+  const priceAmount = course?.price?.amount ?? course?.originalPrice ?? 0;
+  const isPaidCourse = priceAmount > 0;
   const isPurchased = course?.isPurchased ?? false;
 
   const lectures = useMemo(() => flattenCourseLectures(course), [course]);


### PR DESCRIPTION
### Motivation

- Provide a dedicated payment route at `/course/[id]/payment` so unpaid learners are taken to checkout before accessing lessons.
- Use the `course.isPurchased` flag from the course details API to decide whether to show purchase vs learning actions.
- Skip the payment step for free courses (price 0) and surface basic order details so users know what they're purchasing.

### Description

- Add a new payment route and server page at `src/app/course/[id]/payment/page.tsx` that preloads course details and mounts a new `CoursePaymentPage` component.
- Implement `CoursePaymentPage` with an order summary, basic course metadata (title, instructor, duration, price, media) and a payment gateway placeholder under `src/components/pages/CoursePaymentPage/`.
- Update the course hero to accept a `primaryActionLabel` and wire the course detail CTA to conditionally show `Purchase course` or `Start learning` and route to `/course/[id]/payment` when needed.
- Prevent access to the learning UI for paid, unpurchased courses by redirecting from the learning page to the payment route using `course.price.amount` and `course.isPurchased` checks.

### Testing

- Started the dev server with `npm run dev` and verified the app compiled and routes were served successfully.
- Ran a Playwright script to navigate to `http://127.0.0.1:3000/course/1/payment` which redirected unauthenticated users to `/auth/login` and then successfully loaded the payment page when session cookies were provided, producing a screenshot.
- Observed the backend course fetch failing with `ECONNREFUSED` (500) during the run, but the payment page still rendered using mock/fallback course data.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963537aaff4832aaa652eb84db9cd11)